### PR TITLE
Clean up mut not necessary warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ impl NN {
 
             for (node_index, (node, &result)) in iter_zip_enum(layer_nodes, layer_results) {
                 let mut node_weight_updates = Vec::new();
-                let mut node_error;
+                let node_error;
 
                 // calculate error for this node
                 if layer_index == layers.len() - 1 {
@@ -407,7 +407,7 @@ impl NN {
 
                 // calculate weight updates for this node
                 for weight_index in 0..node.len() {
-                    let mut prev_layer_result;
+                    let prev_layer_result;
                     if weight_index == 0 {
                         prev_layer_result = 1f64; // threshold
                     } else {


### PR DESCRIPTION
On rustc 1.9.0 (e4e8b6668 2016-05-18) I get the following warnings:

``` rust
src/lib.rs:394:21: 394:35 warning: variable does not need to be mutable, #[warn(unused_mut)] on src/lib.rs:410:25: 410:46 warning: variable does not need to be mutable, #[warn(unused_mut)] on src/lib.rs:410                     let mut prev_layer_result;
src/lib.rs:394                 let mut node_error;
src/lib.rs:410:25: 410:46 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/lib.rs:410                     let mut prev_layer_result;
                                       ^~~~~~~~~~~~~~~~~~~~~
```

This commit just gets rid of those warnings.
